### PR TITLE
[2024/06/20] feat/refreshtoken>> 리프레쉬 토큰 추가 및 갱신 기능 업데이트

### DIFF
--- a/src/main/java/com/sparta/heartvera/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/heartvera/domain/auth/controller/AuthController.java
@@ -1,13 +1,18 @@
 package com.sparta.heartvera.domain.auth.controller;
 
-import com.sparta.heartvera.domain.auth.dto.LoginRequestDto;
 import com.sparta.heartvera.domain.auth.dto.SignupRequestDto;
+import com.sparta.heartvera.domain.auth.dto.TokenRequestDto;
+import com.sparta.heartvera.domain.auth.dto.TokenResponseDto;
 import com.sparta.heartvera.domain.auth.service.AuthService;
+import com.sparta.heartvera.security.service.UserDetailsImpl;
+import com.sparta.heartvera.security.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +29,22 @@ public class AuthController {
     @PostMapping(value = "/signup")
     public ResponseEntity<String> signup(@RequestBody @Valid SignupRequestDto requestDto){
         return authService.signup(requestDto);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<String> reAuth(@RequestBody TokenRequestDto requestDto, HttpServletResponse response) {
+        String refreshtoken = requestDto.getRefreshToken();
+        TokenResponseDto newToken = authService.reAuth(refreshtoken);
+        // token 추가
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, newToken.getAccessToken());
+
+        return ResponseEntity.ok().body(newToken.getAccessToken());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletRequest request, HttpServletResponse response) {
+        request.removeAttribute(JwtUtil.AUTHORIZATION_HEADER);
+        return authService.logout(userDetails.getUser());
     }
 
 }

--- a/src/main/java/com/sparta/heartvera/domain/auth/dto/TokenRequestDto.java
+++ b/src/main/java/com/sparta/heartvera/domain/auth/dto/TokenRequestDto.java
@@ -1,0 +1,8 @@
+package com.sparta.heartvera.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/sparta/heartvera/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/sparta/heartvera/domain/auth/dto/TokenResponseDto.java
@@ -1,0 +1,18 @@
+package com.sparta.heartvera.domain.auth.dto;
+
+import com.sparta.heartvera.domain.user.entity.UserRoleEnum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponseDto {
+    private UserRoleEnum grantType;
+    private String accessToken;
+    private String refreshToken;
+    private String key;
+}

--- a/src/main/java/com/sparta/heartvera/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/heartvera/domain/user/entity/User.java
@@ -43,4 +43,7 @@ public class User extends Timestamped {
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum authority;
 
+    public void setRefreshToken(String token) {
+        this.refreshToken = token;
+    }
 }

--- a/src/main/java/com/sparta/heartvera/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/heartvera/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId);
+
+    Optional<User> findByRefreshToken(String refreshtoken);
 }

--- a/src/main/java/com/sparta/heartvera/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/heartvera/security/config/WebSecurityConfig.java
@@ -25,11 +25,13 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final UserRepository userRepository;
 
-    public WebSecurityConfig(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, AuthenticationConfiguration authenticationConfiguration) {
+    public WebSecurityConfig(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, AuthenticationConfiguration authenticationConfiguration, UserRepository userRepository) {
         this.jwtUtil = jwtUtil;
         this.userDetailsService = userDetailsService;
         this.authenticationConfiguration = authenticationConfiguration;
+        this.userRepository = userRepository;
     }
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -77,7 +79,7 @@ public class WebSecurityConfig {
     // JWT 인증 필터를 빈으로 정의
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
         // 이 필터는 JWT를 사용하여 인증을 처리하며, 인증 관리자를 설정
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil,userRepository);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         filter.setFilterProcessesUrl("/api/auth/login"); // 로그인 엔드포인트를 설정 (특정 작업을 수행하기 위해 서버에 요청을 보내는 url)
         return filter;

--- a/src/main/java/com/sparta/heartvera/security/util/JwtUtil.java
+++ b/src/main/java/com/sparta/heartvera/security/util/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.sparta.heartvera.security.util;
 
+import com.sparta.heartvera.domain.auth.dto.TokenResponseDto;
 import com.sparta.heartvera.domain.user.entity.UserRoleEnum;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -27,7 +28,8 @@ public class JwtUtil {
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
     // 토큰 만료시간
-    private final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+    private final long ACCESSTOKEN_TIME = 30 * 60 * 1000L; // 30분
+    private final long REFRESHTOKEN_TIME = 12 * 60 * 60 * 1000L; // 12시간
 
     @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
     private String secretKey;
@@ -44,17 +46,32 @@ public class JwtUtil {
     }
 
     // 토큰 생성
-    public String createToken(String username, UserRoleEnum role) {
+    public TokenResponseDto createToken(String userId, UserRoleEnum role) {
         Date date = new Date();
 
-        return BEARER_PREFIX +
+        String accessToken = BEARER_PREFIX +
                 Jwts.builder()
-                        .setSubject(username) // 사용자 식별자값(ID)
+                        .setSubject(userId) // 사용자 식별자값(ID)
                         .claim(AUTHORIZATION_KEY, role) // 사용자 권한
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+                        .setExpiration(new Date(date.getTime() + ACCESSTOKEN_TIME)) // 만료 시간
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘
                         .compact();
+
+        String refreshToken = BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userId) // 사용자 식별자값(ID)
+                        .claim(AUTHORIZATION_KEY, role) // 사용자 권한
+                        .setExpiration(new Date(date.getTime() + REFRESHTOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+
+        return TokenResponseDto.builder()
+                .grantType(role)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .key(userId).build();
     }
 
     // JWT Cookie 에 저장
@@ -83,18 +100,6 @@ public class JwtUtil {
         } catch (UnsupportedEncodingException e) {
             logger.error(e.getMessage());
         }
-    }
-    public String createAccessToken(String username, UserRoleEnum status) {
-        Date date = new Date();
-
-        return BEARER_PREFIX +
-                Jwts.builder()
-                        .setSubject(username) // 사용자 식별자값(ID)
-                        .claim(AUTHORIZATION_KEY, status) // 사용자 권한
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
-                        .setIssuedAt(date) // 발급일
-                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
-                        .compact();
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 
close #18 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
![image](https://github.com/HeartVera/HeartVera/assets/51986588/8ca701f7-7248-4141-82db-788c540eb4e9)
임의로 액세스 토큰 30분 / 리프레쉬 토큰 12시간동안 유효하도록 조정해뒀습니다.

![image](https://github.com/HeartVera/HeartVera/assets/51986588/f30e46ce-2eb0-4c51-a4f2-d1ec1f59eef4)
로그인 시 발급된 액세스 토큰은  "Bearer ~~,,, _4k"

![image](https://github.com/HeartVera/HeartVera/assets/51986588/ce170cd2-a9fb-451a-bb44-2b5bd9da9527)
토큰 재발급시 발급된 액세스 토큰은  "Bearer ~~,,, FkQ" 인것을 확인할 수 있습니다.

토큰 재발급시 request body로 user DB에 있는 refresh token만 넘겨주시면 실행됩니다.

기존  API 명세서와 달라진 부분이 있어 수정했습니다. 노션 API 명세서도 한번 확인해주세요!

리프래쉬 토큰을 이용하여 액세스 토큰과 리프래쉬 토큰을 재발급하고, header와 body로 새로 생성된 access 토큰을 반환합니다.


## 💬리뷰 요구사항(선택)
logout 기능은 profile 관련 기능이 모두 구현된 이후 user controller로 이동 예정입니다.

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
